### PR TITLE
Fix wrong package import in README custom alphabet example

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ A smaller alphabet is not weaker, it just needs a longer id to hold the same 126
 ### Custom alphabet
 
 ```dart
-import 'package:nanoid/nanoid.dart';
+import 'package:nanoid2/nanoid2.dart';
 
 void main() {
   // use your own alphabets


### PR DESCRIPTION
The custom alphabet example imported `package:nanoid`, the package nanoid2 was forked from, so copy-pasting it produced an unresolved import.

```diff
-import 'package:nanoid/nanoid.dart';
+import 'package:nanoid2/nanoid2.dart';
```

The other two examples on the page already use the correct import.
