### PR TITLE
Fix off-by-one in length ArgumentError messages

### DIFF
--- a/lib/nanoid2.dart
+++ b/lib/nanoid2.dart
@@ -40,11 +40,11 @@ String nanoid({
     throw ArgumentError.value(
       length,
       "length",
-      "Length must be greater than 2",
+      "Length must be at least 2",
     );
   }
   if (length > 255) {
-    throw ArgumentError.value(length, "length", "Length must be less than 255");
+    throw ArgumentError.value(length, "length", "Length must be at most 255");
   }
   int i = length;
   if (alphabet != null && alphabet.isEmpty) {

--- a/test/nanoid_test.dart
+++ b/test/nanoid_test.dart
@@ -22,12 +22,32 @@ void main() {
   test('requires min length of 2', () {
     expect(() => nanoid(length: 0), throwsArgumentError);
     expect(() => nanoid(length: 1), throwsArgumentError);
+    expect(
+      () => nanoid(length: 1),
+      throwsA(
+        isArgumentError.having(
+          (it) => it.message,
+          'message',
+          'Length must be at least 2',
+        ),
+      ),
+    );
     nanoid(length: 2);
   });
 
   test('max length is 255', () {
     nanoid(length: 255);
     expect(() => nanoid(length: 256), throwsArgumentError);
+    expect(
+      () => nanoid(length: 256),
+      throwsA(
+        isArgumentError.having(
+          (it) => it.message,
+          'message',
+          'Length must be at most 255',
+        ),
+      ),
+    );
   });
 
   test('custom alphabet', () {


### PR DESCRIPTION
`length: 2` and `length: 255` both generate ids, but the errors described those values as rejected.
Anyone who hit the error was pointed at a length that is itself invalid.

```text
nanoid(length: 1)
  old: Invalid argument (length): Length must be greater than 2: 1
  new: Invalid argument (length): Length must be at least 2: 1

nanoid(length: 256)
  old: Invalid argument (length): Length must be less than 255: 256
  new: Invalid argument (length): Length must be at most 255: 256
```

Message only change, the accepted range is unchanged.
The existing boundary tests now assert the message text too.
