### PR TITLE
Add nanoid topic

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,3 +16,4 @@ topics:
   - uuid
   - id
   - random
+  - nanoid


### PR DESCRIPTION
`nanoid` is the name people search for, but it was the one topic the package did not carry.

```yaml
topics:
  - identifier
  - uuid
  - id
  - random
  - nanoid
```

That is 5 of the 5 topics pub.dev allows, so this fills the last slot.
