### PR TITLE
Add Alphabet.crockfordBase32, base58 and cookieSafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Changelog
 
 ## Unreleased
 
-- Add `Alphabet.crockfordBase32` and `Alphabet.base58`
+- Add `Alphabet.crockfordBase32`, `Alphabet.base58` and `Alphabet.cookieSafe`
 
 ## 2.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog
 
+## Unreleased
+
+- Add `Alphabet.crockfordBase32` and `Alphabet.base58`
+
 ## 2.0.1
 
 - Update pubspec topics description and repo link

--- a/README.md
+++ b/README.md
@@ -39,6 +39,30 @@ void main() {
 }
 ```
 
+### Which alphabet?
+
+Every alphabet trades away characters to gain some property, and pays for it in entropy per character.
+Pick the constraint you actually have, then use the length that keeps you at 126 bits, the same collision resistance as UUID v4 and as the 21 character default.
+
+| Alphabet | Characters | Bits per char | Length for 126 bits | You need |
+| --- | --- | --- | --- | --- |
+| `cookieSafe` | ``[a-zA-Z0-9!#$%&'*+.^_`\|~-]``, 77 chars | 6.27 | 21 | To put the id in a cookie value |
+| `url` | `[a-zA-Z0-9_-]`, 64 chars | 6.00 | 21 | Nothing in particular, this is the default |
+| `base64` | `[a-zA-Z0-9+/]`, 64 chars | 6.00 | 21 | The classic Base64 symbols `+/` instead of `_-` |
+| `alphanumeric` | `[a-zA-Z0-9]`, 62 chars | 5.95 | 22 | Letters and digits, no symbols at all |
+| `base58` | `[1-9A-HJ-NP-Za-km-z]`, 58 chars | 5.86 | 22 | A short id for a URL that nobody dictates |
+| `noDoppelganger` | `[346-9A-HJ-NP-RT-Ya-kmnp-rtw-z]`, 49 chars | 5.61 | 23 | No lookalikes, but vowels are fine |
+| `noDoppelgangerSafe` | `[6-9B-DF-HJ-NP-RTWb-df-hjkmnp-rtwz]`, 36 chars | 5.17 | 25 | An id that can never resemble a word |
+| `crockfordBase32` | `[0-9A-HJKMNP-TV-Z]`, 32 chars | 5.00 | 26 | An id that survives being read out loud or typed back in |
+| `lowercase` | `[a-z]`, 26 chars | 4.70 | 27 | Case-insensitive storage, such as a hostname or a bucket name |
+| `uppercase` | `[A-Z]`, 26 chars | 4.70 | 27 | The same, where the surrounding text is uppercase |
+| `hexadecimalLowercase` | `[0-9a-f]`, 16 chars | 4.00 | 32 | To interoperate with something that parses hex |
+| `hexadecimalUppercase` | `[0-9A-F]`, 16 chars | 4.00 | 32 | The same, where the reader expects uppercase hex |
+| `numbers` | `[0-9]`, 10 chars | 3.32 | 38 | Digits only, for a PIN or a numeric code |
+
+Rows run from the most to the least entropy per character.
+A smaller alphabet is not weaker, it just needs a longer id to hold the same 126 bits.
+
 ### Custom alphabet
 
 ```dart
@@ -59,12 +83,8 @@ void main() {
   nanoid(alphabet: Alphabet.alphanumeric); // [a-zA-Z0-9], 62 chars
   nanoid(alphabet: Alphabet.base64); // [a-zA-Z0-9+/], 64 chars
   nanoid(alphabet: Alphabet.base58); // [1-9A-HJ-NP-Za-km-z], 58 chars
-
-  // Valid in a cookie value without quoting. 77 chars
-  nanoid(alphabet: Alphabet.cookieSafe);
-
-  // Crockford's Base32, made to be read and typed by humans. 32 chars
-  nanoid(alphabet: Alphabet.crockfordBase32);
+  nanoid(alphabet: Alphabet.cookieSafe); // [a-zA-Z0-9!#$%&'*+.^_`|~-], 77 chars
+  nanoid(alphabet: Alphabet.crockfordBase32); // [0-9A-HJKMNP-TV-Z], 32 chars
 
   // Numbers and english letters without lookalikes: 1, l, I, 0, O, o, u, v, 5, S, s, 2, Z. 49 chars
   nanoid(alphabet: Alphabet.noDoppelganger);
@@ -75,7 +95,7 @@ void main() {
 
 ## License
 
-```
+```text
 MIT License
 
 Copyright (c) 2023 Pascal Welsch, Rongjian Zhang, Andrey Sitnik

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ void main() {
   nanoid(alphabet: Alphabet.base64); // [a-zA-Z0-9+/], 64 chars
   nanoid(alphabet: Alphabet.base58); // [1-9A-HJ-NP-Za-km-z], 58 chars
 
+  // Valid in a cookie value without quoting. 77 chars
+  nanoid(alphabet: Alphabet.cookieSafe);
+
   // Crockford's Base32, made to be read and typed by humans. 32 chars
   nanoid(alphabet: Alphabet.crockfordBase32);
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ void main() {
   nanoid(alphabet: Alphabet.uppercase); // [A-Z], 26 chars
   nanoid(alphabet: Alphabet.alphanumeric); // [a-zA-Z0-9], 62 chars
   nanoid(alphabet: Alphabet.base64); // [a-zA-Z0-9+/], 64 chars
+  nanoid(alphabet: Alphabet.base58); // [1-9A-HJ-NP-Za-km-z], 58 chars
+
+  // Crockford's Base32, made to be read and typed by humans. 32 chars
+  nanoid(alphabet: Alphabet.crockfordBase32);
 
   // Numbers and english letters without lookalikes: 1, l, I, 0, O, o, u, v, 5, S, s, 2, Z. 49 chars
   nanoid(alphabet: Alphabet.noDoppelganger);

--- a/example/main.dart
+++ b/example/main.dart
@@ -30,12 +30,10 @@ void customAlphabet() {
   print(nanoid(alphabet: Alphabet.alphanumeric)); // [a-zA-Z0-9], 62 chars
   print(nanoid(alphabet: Alphabet.base64)); // [a-zA-Z0-9+/], 64 chars
   print(nanoid(alphabet: Alphabet.base58)); // [1-9A-HJ-NP-Za-km-z], 58 chars
-
-  // Valid in a cookie value without quoting. 77 chars
-  print(nanoid(alphabet: Alphabet.cookieSafe));
-
-  // Crockford's Base32, made to be read and typed by humans. 32 chars
-  print(nanoid(alphabet: Alphabet.crockfordBase32));
+  print(nanoid(
+      alphabet: Alphabet.cookieSafe)); // [a-zA-Z0-9!#$%&'*+.^_`|~-], 77 chars
+  print(nanoid(
+      alphabet: Alphabet.crockfordBase32)); // [0-9A-HJKMNP-TV-Z], 32 chars
 
   // Numbers and english letters without lookalikes: 1, l, I, 0, O, o, u, v, 5, S, s, 2, Z. 49 chars
   print(nanoid(alphabet: Alphabet.noDoppelganger));

--- a/example/main.dart
+++ b/example/main.dart
@@ -29,6 +29,10 @@ void customAlphabet() {
   print(nanoid(alphabet: Alphabet.uppercase)); // [A-Z], 26 chars
   print(nanoid(alphabet: Alphabet.alphanumeric)); // [a-zA-Z0-9], 62 chars
   print(nanoid(alphabet: Alphabet.base64)); // [a-zA-Z0-9+/], 64 chars
+  print(nanoid(alphabet: Alphabet.base58)); // [1-9A-HJ-NP-Za-km-z], 58 chars
+
+  // Crockford's Base32, made to be read and typed by humans. 32 chars
+  print(nanoid(alphabet: Alphabet.crockfordBase32));
 
   // Numbers and english letters without lookalikes: 1, l, I, 0, O, o, u, v, 5, S, s, 2, Z. 49 chars
   print(nanoid(alphabet: Alphabet.noDoppelganger));

--- a/example/main.dart
+++ b/example/main.dart
@@ -31,6 +31,9 @@ void customAlphabet() {
   print(nanoid(alphabet: Alphabet.base64)); // [a-zA-Z0-9+/], 64 chars
   print(nanoid(alphabet: Alphabet.base58)); // [1-9A-HJ-NP-Za-km-z], 58 chars
 
+  // Valid in a cookie value without quoting. 77 chars
+  print(nanoid(alphabet: Alphabet.cookieSafe));
+
   // Crockford's Base32, made to be read and typed by humans. 32 chars
   print(nanoid(alphabet: Alphabet.crockfordBase32));
 

--- a/lib/nanoid2.dart
+++ b/lib/nanoid2.dart
@@ -119,7 +119,7 @@ abstract class Alphabet {
   static const String base64 = "+/" + alphanumeric;
 
   /// Characters that are valid in a cookie value without quoting or escaping.
-  /// [a-zA-Z0-9] plus `!#$%&'*+-.^_`|~` (77 chars)
+  /// ``[a-zA-Z0-9!#$%&'*+.^_`|~-]`` (77 chars)
   ///
   /// This is the token character set of RFC 7230, a subset of what RFC 6265
   /// allows in a cookie value. The characters RFC 6265 permits on top of these

--- a/lib/nanoid2.dart
+++ b/lib/nanoid2.dart
@@ -117,4 +117,22 @@ abstract class Alphabet {
 
   /// Base64 characters [a-zA-Z0-9+/] (64 chars)
   static const String base64 = "+/" + alphanumeric;
+
+  /// Crockford's Base32, uppercase letters and numbers without the lookalikes
+  /// I, L and O, and without U. [0-9A-HJKMNP-TV-Z] (32 chars)
+  ///
+  /// Made to be read and typed by humans, for example when an id is written
+  /// down or read out loud. U is left out so that generated ids are less
+  /// likely to spell obscene words.
+  ///
+  /// See https://www.crockford.com/base32.html
+  static const String crockfordBase32 = numbers + "ABCDEFGHJKMNPQRSTVWXYZ";
+
+  /// Base58 as used by Bitcoin and IPFS. Letters and numbers without the
+  /// lookalikes 0, O, I and l. [1-9A-HJ-NP-Za-km-z] (58 chars)
+  ///
+  /// Case-sensitive and shorter than [crockfordBase32] for the same entropy,
+  /// which makes it a common choice for ids that end up in URLs.
+  static const String base58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZ"
+      "abcdefghijkmnopqrstuvwxyz";
 }

--- a/lib/nanoid2.dart
+++ b/lib/nanoid2.dart
@@ -118,6 +118,15 @@ abstract class Alphabet {
   /// Base64 characters [a-zA-Z0-9+/] (64 chars)
   static const String base64 = "+/" + alphanumeric;
 
+  /// Characters that are valid in a cookie value without quoting or escaping.
+  /// [a-zA-Z0-9] plus `!#$%&'*+-.^_`|~` (77 chars)
+  ///
+  /// This is the token character set of RFC 7230, a subset of what RFC 6265
+  /// allows in a cookie value. The characters RFC 6265 permits on top of these
+  /// have to be quoted to survive some servers and proxies, so they are left
+  /// out.
+  static const String cookieSafe = alphanumeric + r"!#$%&'*+-.^_`|~";
+
   /// Crockford's Base32, uppercase letters and numbers without the lookalikes
   /// I, L and O, and without U. [0-9A-HJKMNP-TV-Z] (32 chars)
   ///

--- a/test/alphabet_test.dart
+++ b/test/alphabet_test.dart
@@ -15,11 +15,18 @@ void main() {
     expectCharacters(64, Alphabet.base64);
     expectCharacters(32, Alphabet.crockfordBase32);
     expectCharacters(58, Alphabet.base58);
+    expectCharacters(77, Alphabet.cookieSafe);
   });
 
   test('crockfordBase32 excludes lookalikes I, L, O and the letter U', () {
     for (final excluded in ['I', 'L', 'O', 'U']) {
       expect(Alphabet.crockfordBase32, isNot(contains(excluded)));
+    }
+  });
+
+  test('cookieSafe excludes what needs quoting in a cookie value', () {
+    for (final excluded in [' ', '"', ',', ';', r'\', '(', ')', '/', '@']) {
+      expect(Alphabet.cookieSafe, isNot(contains(excluded)));
     }
   });
 

--- a/test/alphabet_test.dart
+++ b/test/alphabet_test.dart
@@ -13,6 +13,20 @@ void main() {
     expectCharacters(62, Alphabet.alphanumeric);
     expectCharacters(64, Alphabet.url);
     expectCharacters(64, Alphabet.base64);
+    expectCharacters(32, Alphabet.crockfordBase32);
+    expectCharacters(58, Alphabet.base58);
+  });
+
+  test('crockfordBase32 excludes lookalikes I, L, O and the letter U', () {
+    for (final excluded in ['I', 'L', 'O', 'U']) {
+      expect(Alphabet.crockfordBase32, isNot(contains(excluded)));
+    }
+  });
+
+  test('base58 excludes lookalikes 0, O, I and l', () {
+    for (final excluded in ['0', 'O', 'I', 'l']) {
+      expect(Alphabet.base58, isNot(contains(excluded)));
+    }
   });
 }
 


### PR DESCRIPTION
The existing `noDoppelganger` alphabets are homegrown.
These are the standard ones people already expect by name, so ids generated with them interoperate with what other systems produce.

```dart
// Crockford's Base32, for ids a human reads out loud or types back in.
nanoid(alphabet: Alphabet.crockfordBase32, length: 26); // F6J399SP385YMNBFMNEA1YB2YW

// Base58, as used by Bitcoin and IPFS. Shorter than Base32 at the same
// entropy because it stays case-sensitive. Good for ids that end up in URLs.
nanoid(alphabet: Alphabet.base58, length: 22); // yKBEBzwwHC7pygkBPJkW52

// Valid in a cookie value without quoting.
nanoid(alphabet: Alphabet.cookieSafe); // CcMKlUm+zw!hwAVxZYg$S
```

| alphabet | chars | excludes |
| --- | --- | --- |
| `crockfordBase32` | 32 | `I` `L` `O` `U` |
| `base58` | 58 | `0` `O` `I` `l` |
| `cookieSafe` | 77 | everything a cookie value must quote |

Also adds a "Which alphabet?" section to the README, because the hard part is picking one, not calling `nanoid()`.
It maps each alphabet to the constraint it solves and lists the length each needs to stay at the 126 bits the default gives you, so swapping to a shorter alphabet does not quietly weaken an id.

`crockfordBase32` and `base58` match their published specs character for character, see [Crockford](https://www.crockford.com/base32.html) and Bitcoin Base58.
`cookieSafe` matches the entry of the same name in [nanoid-dictionary](https://github.com/CyberAP/nanoid-dictionary), so ids stay interchangeable with the JavaScript ports.
