### PR TITLE
Fix CI on main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: dart pub get
       - name: Format
         run: dart format --set-exit-if-changed .
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Format
-        run: dart format --set-exit-if-changed --fix .
+        run: dart format --set-exit-if-changed .
 
   lint:
     timeout-minutes: 5

--- a/lib/nanoid2.dart
+++ b/lib/nanoid2.dart
@@ -9,7 +9,7 @@ import 'dart:math';
 ///
 /// Examples:
 ///
-/// ```
+/// ```text
 /// BGmaV2KoFx0Ar2yS6zMDc
 /// TZGlaZw38c43IILQQ-Jxc
 /// n_vyOfT-Q9hwWyYQZSYop


### PR DESCRIPTION
`Dart CI` is red on `main` without anyone touching the code, because the workflows run `dart:stable` and the SDK moved underneath them.
The `test` matrix is unaffected.

- `dart format` dropped `--fix`, so the format job exited 64 before checking anything.
- The format job also never ran `pub get`, so the formatter could not read the package language version and used the current default style.
- The analyzer gained `missing_code_block_language_in_doc_comment`, which `--fatal-infos` turns into a failure.
  The block lists generated ids rather than Dart, so it is tagged `text`.

Should land before the four open PRs so they can rebase onto a green `main`.
