### PR TITLE
Prepare Release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,27 @@
 Changelog
 
-## Unreleased
+## 2.1.0
 
-- Add `Alphabet.crockfordBase32`, `Alphabet.base58` and `Alphabet.cookieSafe`
+- **New** `Alphabet.crockfordBase32`, [Crockford's Base32](https://www.crockford.com/base32.html), for ids a human reads out loud or types back in.
+  Drops the lookalikes `I` `L` `O`, and `U` so ids are less likely to spell words (32 chars) [#5](https://github.com/passsy/nanoid2/pull/5)
+
+  ```dart
+  nanoid(alphabet: Alphabet.crockfordBase32, length: 26); // F6J399SP385YMNBFMNEA1YB2YW
+  ```
+
+- **New** `Alphabet.base58`, as used by Bitcoin and IPFS.
+  Drops the lookalikes `0` `O` `I` `l` and stays case sensitive, so it is shorter than Base32 at the same entropy (58 chars) [#5](https://github.com/passsy/nanoid2/pull/5)
+
+  ```dart
+  nanoid(alphabet: Alphabet.base58, length: 22); // yKBEBzwwHC7pygkBPJkW52
+  ```
+
+- **New** `Alphabet.cookieSafe`, valid in a cookie value without quoting or escaping (77 chars) [#5](https://github.com/passsy/nanoid2/pull/5)
+- **Fix** The `length` `ArgumentError` messages named the wrong bounds, calling 2 and 255 invalid when both generate ids [#3](https://github.com/passsy/nanoid2/pull/3)
+- **Fix** `repository` pointed at the repository's old name, so pub.dev could not verify it. Added `issue_tracker`
+- The README gained a `Which alphabet?` table listing every alphabet with its entropy per character [#5](https://github.com/passsy/nanoid2/pull/5), and a `Collisions` section that charts how many ids each alphabet and length is good for [#7](https://github.com/passsy/nanoid2/pull/7)
+
+[diff v2.0.1...v2.1.0](https://github.com/passsy/nanoid2/compare/v2.0.1...v2.1.0)
 
 ## 2.0.1
 
@@ -25,7 +44,7 @@ New APIs:
 
 ## 1.0.0
 
-This package is a fork of https://pub.dev/packages/nanoid
+This package is a fork of [package:nanoid](https://pub.dev/packages/nanoid)
 
 Many features have been removed to make the API more Dart-like.
-Please get support for 1.0.0 from the original package at https://github.com/pd4d10/nanoid-dart.
+Please get support for 1.0.0 from the original package at [pd4d10/nanoid-dart](https://github.com/pd4d10/nanoid-dart).

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: nanoid2
-version: 2.0.1
+version: 2.1.0
 description: A tiny, secure, URL-friendly, unique string ID generator, nanoid with a pure Dart API.
 repository: https://github.com/passsy/nanoid2
 issue_tracker: https://github.com/passsy/nanoid2/issues


### PR DESCRIPTION
Bumps `version` to 2.1.0 and writes the changelog.
Minor, not major: the three new alphabets are static constants on `Alphabet`, which do not touch its implicit interface, and nothing was removed or renamed.

`dart pub publish --dry-run` reports 0 warnings.
The published 2.0.1 also carried a broken `repository` link that pub.dev refused to verify, costing 10 pub points; that fix has sat unreleased on `main` since 2023, so publishing recovers it.

`v2.0.1` now exists, tagged retroactively at `1d584fe`, which is byte identical to the published 2.0.1 across all ten files in the archive.
The changelog's diff link points at `v2.0.1...v2.1.0` and goes live once you tag `v2.1.0`.

One thing left for you to decide: `doc/collision_risk.svg` ships inside the archive at 13 KB, though the README loads it from GitHub by absolute URL so the packaged copy is never read.
The whole archive is still 10 KB compressed.
Say the word and I will add a `.pubignore`.
